### PR TITLE
Use relative path for tlmviewer.js

### DIFF
--- a/test_notebooks/tlmviewer.js
+++ b/test_notebooks/tlmviewer.js
@@ -1,1 +1,1 @@
-/home/victor/projects/tlmviewer/dist/tlmviewer.js
+../../tlmviewer/dist/tlmviewer.js


### PR DESCRIPTION
Assumes `tlmviewer` lives in a sibling directory.